### PR TITLE
Clarifying one location, and edited the description

### DIFF
--- a/src/app/data/locations.js
+++ b/src/app/data/locations.js
@@ -63,9 +63,9 @@ export const location_data = [
         }
     },
     {
-        "name": "Estelita’s Library (coming soon)",
+        "name": "Estelita’s Library (Central District)",
         "address": "241 Martin Luther King Jr Way S, Seattle, WA 98144",
-        "full_description": "We hope to build this sometime in July 2025. Stay tuned! Will include a full-sized fridge, large pantry, street sink, and mutual aid station.",
+        "full_description": "Estelita's Library's fridge is now available! The full-sized fridge, public telephone (provided by Futel), and free WiFi are fully operational. The large pantry, street sink, and mutual aid station are currently under construction.",
         "coord": {
             lat: 47.600396775707445,
             lng: -122.2972817120421


### PR DESCRIPTION
Updating since the library fridge is available. Also noted that it's at the Central District in case people go to the old location in Beacon Hill.

<img width="1084" height="515" alt="image" src="https://github.com/user-attachments/assets/23849358-be84-46aa-af3b-1c5bceb865bc" />
